### PR TITLE
Front-end refactor first pass

### DIFF
--- a/api/bootstrapper.go
+++ b/api/bootstrapper.go
@@ -99,7 +99,7 @@ func handleListRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(roles)
 }
 
-// TODO: Support looking in different regions based on query param
+// TODO: Support looking in different regions based on query param (adjust the front-end query too)
 func handleListClusters(c *Context, w http.ResponseWriter, r *http.Request) {
 	result, err := c.CloudProvider.ListClusters(c.Ctx)
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -48,7 +48,7 @@ export default function JoyOrderDashboardTemplate() {
               <AWSPage />
             </>
           } />
-          <Route path="/aws/existing" element={
+          <Route path="/:cloudProvider/existing" element={
             <>
               <BootstrapperHeader currentStep={'create_eks_cluster'}/>
               <ExistingAWSPage />
@@ -66,19 +66,19 @@ export default function JoyOrderDashboardTemplate() {
               <ProvisionClusterPage />
             </>
           } />
-          <Route path="/cluster/summary" element={
+          <Route path="/:cloudProvider/cluster/summary" element={
             <>
               <BootstrapperHeader currentStep={'cluster_summary'}/>
               <ClusterSummaryPage />
             </>
           } />
-          <Route path="/cluster/operators" element={
+          <Route path="/:cloudProvider/cluster/operators" element={
             <>
               <BootstrapperHeader currentStep={'install_mattermost'}/>
               <InstallOperatorsPage />
             </>
           } />
-          <Route path ="/create_mattermost_workspace" element={
+          <Route path ="/:cloudProvider/create_mattermost_workspace" element={
             <>
               <BootstrapperHeader currentStep={'create_mattermost_workspace'}/>
               <CreateWorkspacePage />

--- a/webapp/src/client/bootstrapperApi.ts
+++ b/webapp/src/client/bootstrapperApi.ts
@@ -1,0 +1,79 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { AWSNodeGroup, CloudCredentials, Namespace, Release } from "../types/bootstrapper";
+import { RootState } from '../store';
+import { baseUrl } from './client';
+import { Cluster } from '../types/Cluster';
+
+export const bootstrapperApi = createApi({
+    reducerPath: 'bootstrapperApi',
+    baseQuery: fetchBaseQuery({ baseUrl: `${baseUrl}/api/v1` }),
+    tagTypes: ['Namespaces', 'HelmReleases', 'MattermostWorkspace', 'NginxOperator', 'CloudNativePGOperator', 'MattermostOperator', 'NginxOperator', 'CloudNativePGOperator', 'CloudCredentials'],
+    endpoints: (builder) => ({
+        setAndCheckCloudCredentials: builder.mutation({
+            query: ({ credentials, cloudProvider }) => ({
+                url: `${cloudProvider}/set_credentials`,
+                method: 'POST',
+                body: credentials as CloudCredentials,
+            }),
+        }),
+        // TODO: pass through the region once the backend supports it
+        getPossibleClusters: builder.query<string[], {cloudProvider: string, region: string}>({
+            query: ({cloudProvider, region}) => `/${cloudProvider}/clusters`,
+        }),
+        getCluster: builder.query<Cluster, {clusterName: string, cloudProvider: string}>({
+            query: ({ clusterName, cloudProvider }: {clusterName: string, cloudProvider: string}) => `/${cloudProvider}/cluster/${clusterName}`,
+        }),
+        getNodegroups: builder.query<AWSNodeGroup[], {cloudProvider: string, clusterName: string}>({
+            query: ({ cloudProvider, clusterName }) => `/${cloudProvider}/cluster/${clusterName}/nodegroups`,
+        }),
+        getKubeConfig: builder.query<string, { cloudProvider: string, clusterName: string }>({
+            query: (({ clusterName, cloudProvider }) => {
+                return { 
+                    url: `/${cloudProvider}/cluster/${clusterName}/kubeconfig`,
+                    responseHandler: (response) => response.text(),
+                }
+            }),
+        }),
+        getNamespaces: builder.query<Namespace[], { cloudProvider: string, clusterName: string }>({
+            query: ({ cloudProvider, clusterName }) => `/${cloudProvider}/cluster/${clusterName}/namespaces`,
+        }),
+        getInstalledHelmReleases: builder.query<Release[], { cloudProvider: string, clusterName: string }>({
+            query: ({ cloudProvider, clusterName }) => `/${cloudProvider}/cluster/${clusterName}/installed_charts`,
+            providesTags: ['HelmReleases']
+        }),
+        deployMattermostOperator: builder.mutation<undefined, {cloudProvider: string, clusterName: string}>({
+            query: ({clusterName, cloudProvider}) => ({
+                url: `/${cloudProvider}/cluster/${clusterName}/deploy_mattermost_operator`,
+                method: 'POST',
+            }),
+        }),
+        deployNginxOperator: builder.mutation<undefined, {cloudProvider: string, clusterName: string}>({
+            query: ({clusterName, cloudProvider}) => ({
+                url: `/${cloudProvider}/cluster/${clusterName}/deploy_nginx_operator`,
+                method: 'POST',
+            }),
+        }),
+        deployCloudNativePG: builder.mutation<undefined, {cloudProvider: string, clusterName: string}>({
+            query: ({clusterName, cloudProvider}) => ({
+                url: `/${cloudProvider}/cluster/${clusterName}/deploy_pg_operator`,
+                method: 'POST',
+            }),
+        }),
+    }),
+});
+
+
+export const selectCloudCredentials = (state: RootState) => state.bootstrapper.cloudCredentials;
+
+export const {
+    useSetAndCheckCloudCredentialsMutation,
+    useGetNamespacesQuery,
+    useDeployMattermostOperatorMutation,
+    useDeployNginxOperatorMutation,
+    useDeployCloudNativePGMutation,
+    useGetInstalledHelmReleasesQuery,
+    useGetPossibleClustersQuery,
+    useGetClusterQuery,
+    useGetNodegroupsQuery,
+    useGetKubeConfigQuery,
+} = bootstrapperApi;

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -1,5 +1,4 @@
-import { CreateMattermostWorkspaceRequest } from "../types/Installation";
-import { CloudCredentials, CreateAWSNodeGroup, CreateEKSClusterRequest } from "../types/bootstrapper";
+import { CreateAWSNodeGroup, CreateEKSClusterRequest } from "../types/bootstrapper";
 
 export const baseUrl = process.env.NODE_ENV == 'development' ? 'http://localhost:3000' : 'http://localhost:8070';
 
@@ -12,19 +11,6 @@ export async function getInstallationByID(id: string) {
 export async function deleteInstallation(id: string) {
     const response = await fetch(`${baseUrl}/api/v1/installation/${id}`, {
         method: 'DELETE'
-    });
-    const data = await response.json();
-    return data;
-}
-
-
-export async function setAndCheckCloudCredentials(credentials: CloudCredentials, provider: string) {
-    const response = await fetch(`${baseUrl}/api/v1/${provider}/set_credentials`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(credentials)
     });
     const data = await response.json();
     return data;
@@ -79,57 +65,6 @@ export async function createEKSNodeGroup(clusterName: string, createNodeGroup: C
             'Content-Type': 'application/json'
         },
         body: JSON.stringify(createNodeGroup)
-    });
-    const data = await response.json();
-    return data;
-}
-
-
-export async function deployMattermostOperator(clusterName: string) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/deploy_mattermost_operator`, {
-        method: 'POST',
-    });
-    const data = await response.json();
-    return data;
-}
-
-export async function deployCloudNativePG(clusterName: string) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/deploy_pg_operator`, {
-        method: 'POST',
-    });
-    const data = await response.json();
-    return data;
-
-}
-
-export async function deployNginxOperator(clusterName: string) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/deploy_nginx_operator`, {
-        method: 'POST',
-    });
-    const data = await response.json();
-    return data;
-}
-
-export async function fetchEKSNamespaces(clusterName: string) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/namespaces`);
-    const data = await response.json();
-    return data;
-}
-
-export async function fetchInstalledHelmReleases(clusterName: string) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/installed_charts`);
-    const data = await response.json();
-    return data;
-}
-
-
-export async function doCreateMattermostWorkspace(clusterName: string, installation: CreateMattermostWorkspaceRequest) {
-    const response = await fetch(`${baseUrl}/api/v1/aws/cluster/${clusterName}/installation`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(installation)
     });
     const data = await response.json();
     return data;

--- a/webapp/src/client/dashboardApi.ts
+++ b/webapp/src/client/dashboardApi.ts
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { baseUrl } from './client';
-import { Mattermost, PatchMattermostWorkspaceRequest } from '../types/Installation';
+import { CreateMattermostWorkspaceRequest, Mattermost, PatchMattermostWorkspaceRequest } from '../types/Installation';
 import { Cluster } from '../types/Cluster';
 
 export const dashboardApi = createApi({
@@ -12,7 +12,7 @@ export const dashboardApi = createApi({
             query: (cloudProvider) => `/${cloudProvider}/clusters`,
         }),
         getMattermostInstallationsForCluster: builder.query<Mattermost[], { clusterName: string, cloudProvider: string }>({
-            query: ({ clusterName, cloudProvider }) => `${cloudProvider}/cluster/${clusterName}/installations`,
+            query: ({ clusterName, cloudProvider }) => `/${cloudProvider}/cluster/${clusterName}/installations`,
             providesTags: (result, error, { clusterName }) =>
                 result
                     ? [
@@ -22,23 +22,30 @@ export const dashboardApi = createApi({
                     : [{ type: 'Installation' as const, id: clusterName }], // Tag on error too 
         }),
         getCluster: builder.query<Cluster, { clusterName: string, cloudProvider: string }>({
-            query: ({ clusterName, cloudProvider }) => `${cloudProvider}/cluster/${clusterName}`,
+            query: ({ clusterName, cloudProvider }) => `/${cloudProvider}/cluster/${clusterName}`,
         }),
         deleteInstallation: builder.mutation<void, { clusterName: string, cloudProvider: string, installationName: string }>({
             query: ({ clusterName, cloudProvider, installationName }) => ({
-                url: `${cloudProvider}/cluster/${clusterName}/installation/${installationName}`,
+                url: `/${cloudProvider}/cluster/${clusterName}/installation/${installationName}`,
                 method: 'DELETE'
             }),
         }),
         patchInstallation: builder.mutation<Mattermost, { clusterName: string, cloudProvider: string, installationName: string, patch: PatchMattermostWorkspaceRequest }>({
             query: ({ clusterName, cloudProvider, installationName, patch }) => ({
-                url: `${cloudProvider}/cluster/${clusterName}/installation/${installationName}`,
+                url: `/${cloudProvider}/cluster/${clusterName}/installation/${installationName}`,
                 method: 'PATCH',
                 body: patch
             }),
             invalidatesTags: ['Installation']
         }),
+        createMattermostWorkspace: builder.mutation<Mattermost, {cloudProvider: string, clusterName: string, workspaceInfo: CreateMattermostWorkspaceRequest}>({
+            query: ({ cloudProvider, clusterName, workspaceInfo }) => ({
+                url: `/${cloudProvider}/cluster/${clusterName}/installation`,
+                method: 'POST',
+                body: workspaceInfo,
+            }),
+        }),
     }),
 });
 
-export const { useGetMattermostInstallationsForClusterQuery, useGetClustersQuery, useDeleteInstallationMutation, usePatchInstallationMutation } = dashboardApi;
+export const { useGetMattermostInstallationsForClusterQuery, useGetClustersQuery, useDeleteInstallationMutation, usePatchInstallationMutation, useCreateMattermostWorkspaceMutation } = dashboardApi;

--- a/webapp/src/components/common/rtk_connected_loading_spinner.tsx
+++ b/webapp/src/components/common/rtk_connected_loading_spinner.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { CircularProgress } from '@mui/joy';
+import CheckIcon from '@mui/icons-material/Check';
+
+import { ErrorOutline } from '@mui/icons-material';
+import './connected_loading_spinner.scss';
+
+type Props = {
+    isLoading: boolean;
+    isFetching?: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+}
+
+export default function RTKConnectedLoadingSpinner(props: Props) {
+    let content = null;
+    let className = '';
+    // RTK Query refetches don't set isLoading = true, so support checking isFetching as well
+    if (props.isLoading || props.isFetching) {
+        content = <CircularProgress />;
+        className='loading';
+    } else if (props.isSuccess) {
+        content = <div className="info"><CheckIcon fontSize='small' /> Connected successfully!</div>;
+        className='succeeded';
+    } else if (props.isError) {
+        content = <div className="info"><ErrorOutline /> An error has occurred</div>;
+        className='failed';
+    }
+
+    return (
+        <div className={`ConnectedLoadingSpinner__${className}`}>
+            {content}
+        </div>
+    );
+}

--- a/webapp/src/pages/aws/provision_cluster/index.tsx
+++ b/webapp/src/pages/aws/provision_cluster/index.tsx
@@ -139,7 +139,8 @@ export default function ProvisionClusterPage() {
                             ))}
                             {nodeGroups && nodeGroups?.length > 0 &&
                                 <div className="next-step">
-                                    <Button disabled={nodeGroups[0].Status !== 'ACTIVE'} onClick={() => navigate(`/cluster/summary?clusterName=${cluster?.Name}&type=eks`)} size="lg" color="primary">Next Step</Button>
+                                    {/* TODO: Update with variable cloudProvider */}
+                                    <Button disabled={nodeGroups[0].Status !== 'ACTIVE'} onClick={() => navigate(`/aws/cluster/summary?clusterName=${cluster?.Name}&type=eks`)} size="lg" color="primary">Next Step</Button>
                                 </div>}
                             {(!nodeGroups || !nodeGroups?.length) && <>
                                 <label>Node Groups</label>

--- a/webapp/src/pages/install_operators/install_mattermost.tsx
+++ b/webapp/src/pages/install_operators/install_mattermost.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default function InstallMattermost() {
-    return (
-        <div></div>
-    );
-}

--- a/webapp/src/pages/install_operators/install_nginx.tsx
+++ b/webapp/src/pages/install_operators/install_nginx.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-
-export default function InstallNginx() {
-    return (
-        <div></div>
-    );
-}

--- a/webapp/src/pages/mattermost/db_connection.tsx
+++ b/webapp/src/pages/mattermost/db_connection.tsx
@@ -1,8 +1,5 @@
 import React, { useEffect } from 'react';
 import { Release } from '../../types/bootstrapper';
-import { useSelector } from 'react-redux';
-import { hasDeployedHelmChart } from '../../store/installation/bootstrapperSlice';
-import { RootState } from '../../store';
 import { Input, Option, Select } from '@mui/joy';
 
 
@@ -14,7 +11,7 @@ type DBConnectionInputProps = {
 export type DBConnectionDetails = {createDBForMe: boolean, dbConnectionString: string, dbReplicasConnectionString: string}
 
 export default function DBConnection({releases, onChange}: DBConnectionInputProps) {
-    const hasDeployedPGOperator = useSelector((state: RootState) => hasDeployedHelmChart(state, 'cnpg-system'));
+    const hasDeployedPGOperator = releases.some((release) => release.Name === 'cnpg-system');;
     const [createForMe, setCreateForMe] = React.useState<boolean | null>(null);
     const [dbConnectionString, setDBConnectionString] = React.useState('');
     const [dbReplicasConnectionString, setDBReplicasConnectionString] = React.useState('');

--- a/webapp/src/pages/setup/index.tsx
+++ b/webapp/src/pages/setup/index.tsx
@@ -7,10 +7,10 @@ import GetCredentials from './get_credentials';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
-import { setAndCheckCloudCredentials, setCloudCredentials, setCloudProvider, setKubernetesOption } from '../../store/installation/bootstrapperSlice';
-import ConnectedLoadingSpinner from '../../components/common/connected_loading_spinner';
+import { setCloudCredentials, setCloudProvider, setKubernetesOption } from '../../store/installation/bootstrapperSlice';
 import { useNavigate } from 'react-router-dom';
-
+import { useSetAndCheckCloudCredentialsMutation } from '../../client/bootstrapperApi';
+import RTKConnectedLoadingSpinner from '../../components/common/rtk_connected_loading_spinner';
 
 export default function SetupPage() {
     const dispatch = useDispatch();
@@ -19,10 +19,10 @@ export default function SetupPage() {
     const cloudProvider = useSelector((state: RootState) => state.bootstrapper.cloudProvider)
     const kubernetesOption = useSelector((state: RootState) => state.bootstrapper.kubernetesOption)
     const credentials = useSelector((state: RootState) => state.bootstrapper.cloudCredentials)
-    const requestState = useSelector((state: RootState) => state.bootstrapper.status)
+    const [setCredentials, result] = useSetAndCheckCloudCredentialsMutation();
 
     const handleSubmit = async () => {
-        dispatch(setAndCheckCloudCredentials({credentials, cloudProvider}) as any)
+        setCredentials({credentials, cloudProvider});
     }
 
     return (
@@ -49,9 +49,9 @@ export default function SetupPage() {
                             </Select>
                             <SelectKubernetesOption cloudProvider={cloudProvider} onChange={(value) => dispatch(setKubernetesOption(value))} />
                             <GetCredentials cloudProvider={cloudProvider} kubernetesOption={kubernetesOption} onCredentialsChange={(credentials) => dispatch(setCloudCredentials(credentials))}/>
-                            {cloudProvider && kubernetesOption && credentials.accessKeyId && credentials.accessKeySecret && requestState !== 'succeeded' && <Button onClick={handleSubmit} size="lg" color="primary">Submit</Button>}
-                            <ConnectedLoadingSpinner state={requestState} />
-                            {requestState === 'succeeded' && <Button size="lg" color="primary" onClick={() => {navigate(`/${cloudProvider}/${kubernetesOption}`)}}>Next Step</Button>}
+                            {cloudProvider && kubernetesOption && credentials.accessKeyId && credentials.accessKeySecret && !result.isSuccess && <Button onClick={handleSubmit} size="lg" color="primary">Submit</Button>}
+                            <RTKConnectedLoadingSpinner isLoading={result.isLoading} isSuccess={result.isSuccess} isError={result.isError} />
+                            {result.isSuccess && <Button size="lg" color="primary" onClick={() => {navigate(`/${cloudProvider}/${kubernetesOption}`)}}>Next Step</Button>}
                         </div>
                     </div>
                 </div>

--- a/webapp/src/store/index.ts
+++ b/webapp/src/store/index.ts
@@ -3,6 +3,7 @@ import bootstrapperSlice from './installation/bootstrapperSlice'
 import awsSlice from './installation/awsSlice'
 import dashboardSlice from './installation/dashboardSlice'
 import { dashboardApi } from '../client/dashboardApi'
+import {bootstrapperApi} from '../client/bootstrapperApi'
 
 export const store = configureStore({
     reducer: {
@@ -10,9 +11,10 @@ export const store = configureStore({
         bootstrapper: bootstrapperSlice,
         aws: awsSlice,
         [dashboardApi.reducerPath]: dashboardApi.reducer,
+        [bootstrapperApi.reducerPath]: bootstrapperApi.reducer,
     },
     middleware: (getDefaultMiddleware) => 
-    getDefaultMiddleware().concat(dashboardApi.middleware),
+    getDefaultMiddleware().concat(dashboardApi.middleware).concat(bootstrapperApi.middleware),
 })
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/webapp/src/store/installation/bootstrapperSlice.ts
+++ b/webapp/src/store/installation/bootstrapperSlice.ts
@@ -1,80 +1,21 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { CloudCredentials, Release } from "../../types/bootstrapper";
-import { setAndCheckCloudCredentials as setCredentials, deployMattermostOperator as depMattermostOperator, deployNginxOperator as depNginxOperator, deployCloudNativePG as depCloudNativePG, fetchEKSNamespaces, fetchInstalledHelmReleases, doCreateMattermostWorkspace } from '../../client/client';
+import { createSlice } from "@reduxjs/toolkit";
+import { CloudCredentials } from "../../types/bootstrapper";
 import { KubeUtility, allUtilities } from "../../pages/install_operators/install_operators";
 import { RootState } from "..";
-import { CreateMattermostWorkspaceRequest } from "../../types/Installation";
 
 export interface BootstrapperState {
-    status: 'idle' | 'loading' | 'failed' | 'succeeded';
-    createMattermostWorkspaceRequestStatus: 'idle' | 'loading' | 'failed' | 'succeeded';
-    error?: string | undefined;
     cloudProvider: string;
     kubernetesOption: string;
     cloudCredentials: CloudCredentials;
     utilities: KubeUtility[];
-    cluster: {
-        namespacesRequestStatus: 'idle' | 'loading' | 'failed' | 'succeeded',
-        releasesRequestStatus: 'idle' | 'loading' | 'failed' | 'succeeded',
-        namespaces: string[]
-        releases: Release[];
-    };
 }
 
 const initialState: BootstrapperState = {
-    status: 'idle',
-    createMattermostWorkspaceRequestStatus: 'idle',
     cloudProvider: '',
     kubernetesOption: '',
     cloudCredentials: { accessKeyId: '', accessKeySecret: '', region: '', kubeconfig: '' },
     utilities: allUtilities,
-    cluster: {namespacesRequestStatus: 'idle', releasesRequestStatus: 'idle', namespaces: [], releases: []},
 }
-
-export const setAndCheckCloudCredentials = createAsyncThunk("bootstrapper/setAndCheckCloudCredentials", async ({ credentials, cloudProvider }: { credentials: CloudCredentials, cloudProvider: string }) => {
-    const response = await setCredentials(credentials, cloudProvider)
-    return response;
-})
-
-export const getNamespaces = createAsyncThunk("bootstrapper/getNamespaces", async (clusterName: string) => {
-    const response = await fetchEKSNamespaces(clusterName)
-    return response;
-});
-
-export const deployMattermostOperator = createAsyncThunk("bootstrapper/deployMattermostOperator", async (clusterName: string) => {
-    const response = await depMattermostOperator(clusterName)
-    return {utility: 'mattermost-operator', ...response};
-});
-
-export const deployNginxOperator = createAsyncThunk("bootstrapper/deployNginxOperator", async (clusterName: string) => {
-    const response = await depNginxOperator(clusterName)
-    return {utility: 'ingress-nginx', ...response};
-});
-
-export const deployCloudNativePG = createAsyncThunk("bootstrapper/deployCloudNativePG", async (clusterName: string) => {
-    const response = await depCloudNativePG(clusterName);
-    return {utility: 'cnpg', ...response};
-});
-
-export const getInstalledHelmReleases = createAsyncThunk("bootstrapper/getInstalledHelmReleases", async (clusterName: string) => {
-    const response = await fetchInstalledHelmReleases(clusterName);
-    return response;
-});
-
-export const createMattermostWorkspace = createAsyncThunk("bootstrapper/createMattermostWorkspace", async ({clusterName, workspaceInfo}:{clusterName: string, workspaceInfo: CreateMattermostWorkspaceRequest}) => {
-    const response = await doCreateMattermostWorkspace(clusterName, workspaceInfo);
-    return response;
-});
-
-export const deployMariner = createAsyncThunk("bootstrapper/deployMariner", async (clusterName: string) => {
-
-    return null;
-});
-
-export const deployProvisioner = createAsyncThunk("bootstrapper/deployProvisioner", async (clusterName: string) => {
-
-    return null;
-});
 
 export const bootstrapperSlice = createSlice({
     name: 'bootstrapper',
@@ -100,113 +41,8 @@ export const bootstrapperSlice = createSlice({
                 return util;
             });
         },
-        setCreateWorkspaceRequestState: (state, action) => {
-            state.createMattermostWorkspaceRequestStatus = action.payload;
-        },
     },
     extraReducers: (builder) => {
-        builder
-            .addCase(setAndCheckCloudCredentials.pending, (state) => {
-                state.status = 'loading';
-            })
-            .addCase(setAndCheckCloudCredentials.fulfilled, (state) => {
-                state.status = 'succeeded';
-            })
-            .addCase(setAndCheckCloudCredentials.rejected, (state, action) => {
-                state.status = 'failed';
-                state.error = action.error.message;
-            });
-        builder
-            .addCase(getNamespaces.pending, (state) => {
-                state.cluster.namespacesRequestStatus = 'loading';
-            }).addCase(getNamespaces.fulfilled, (state, action) => {
-                state.cluster.namespacesRequestStatus = 'succeeded';
-                state.cluster.namespaces = action.payload.map((namespace: any) => namespace.metadata.name);
-            }).addCase(getNamespaces.rejected, (state, action) => {
-                state.cluster.namespacesRequestStatus = 'failed';
-            });
-
-        builder.addCase(deployMattermostOperator.pending, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'mattermost-operator') {
-                    return { ...utility, deploymentRequestState: 'loading' }
-                }
-                return utility;
-            });
-        }).addCase(deployMattermostOperator.fulfilled, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'mattermost-operator') {
-                    return { ...utility, deploymentRequestState: 'succeeded' }
-                }
-                return utility;
-            });
-        }).addCase(deployMattermostOperator.rejected, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'mattermost-operator') {
-                    return { ...utility, deploymentRequestState: 'failed' }
-                }
-                return utility;
-            });
-        });
-        builder.addCase(deployNginxOperator.pending, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'ingress-nginx') {
-                    return { ...utility, deploymentRequestState: 'loading' }
-                }
-                return utility;
-            });
-        }).addCase(deployNginxOperator.fulfilled, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'ingress-nginx') {
-                    return { ...utility, deploymentRequestState: 'succeeded' }
-                }
-                return utility;
-            });
-        }).addCase(deployNginxOperator.rejected, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'ingress-nginx') {
-                    return { ...utility, deploymentRequestState: 'failed' }
-                }
-                return utility;
-            });
-        });
-        builder.addCase(deployCloudNativePG.pending, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'cnpg-system') {
-                    return { ...utility, deploymentRequestState: 'loading' }
-                }
-                return utility;
-            });
-        }).addCase(deployCloudNativePG.fulfilled, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'cnpg-system') {
-                    return { ...utility, deploymentRequestState: 'succeeded' }
-                }
-                return utility;
-            });
-        }).addCase(deployCloudNativePG.rejected, (state, action) => {
-            state.utilities = state.utilities.map((utility) => {
-                if (utility.key === 'cnpg-system') {
-                    return { ...utility, deploymentRequestState: 'failed' }
-                }
-                return utility;
-            });
-        });
-        builder.addCase(getInstalledHelmReleases.pending, (state) => {
-            state.cluster.releasesRequestStatus = 'loading';
-        }).addCase(getInstalledHelmReleases.fulfilled, (state, action) => {
-            state.cluster.releasesRequestStatus = 'succeeded';
-            state.cluster.releases = action.payload;
-        }).addCase(getInstalledHelmReleases.rejected, (state) => {
-            state.cluster.releasesRequestStatus = 'failed';
-        });
-        builder.addCase(createMattermostWorkspace.pending, (state) => {
-            state.createMattermostWorkspaceRequestStatus = 'loading';
-        }).addCase(createMattermostWorkspace.fulfilled, (state) => {
-            state.createMattermostWorkspaceRequestStatus = 'succeeded';
-        }).addCase(createMattermostWorkspace.rejected, (state) => {
-            state.createMattermostWorkspaceRequestStatus = 'failed';
-        });
     }
 });
 
@@ -219,11 +55,7 @@ export const requiredUtilitiesAreDeployed = (state: RootState) => {
     return requiredUtilities.every((utility: KubeUtility) => utility.isRequired && utility.deploymentRequestState === 'succeeded');
 }
 
-export const hasDeployedHelmChart = (state: RootState, chartName: string) => {
-    return state.bootstrapper.cluster.releases.some((release) => release.Name === chartName);
-}
-
-export const { setCloudProvider, setCloudCredentials, setKubernetesOption, setUtilities, setUtilityDeploymentState, setCreateWorkspaceRequestState } = bootstrapperSlice.actions;
+export const { setCloudProvider, setCloudCredentials, setKubernetesOption, setUtilities, setUtilityDeploymentState } = bootstrapperSlice.actions;
 
 
 export default bootstrapperSlice.reducer;

--- a/webapp/src/types/Cluster.ts
+++ b/webapp/src/types/Cluster.ts
@@ -9,6 +9,7 @@ export type Cluster = {
 	Status?: ClusterStatus; 
 	Tags?: { [key: string]: string };
 	Version?: string;
+    Arn?: string;
 };
 
 export type ClusterStatus = "CREATING" | "ACTIVE" | "DELETING" | "FAILED" | "UPDATING";

--- a/webapp/src/types/bootstrapper.ts
+++ b/webapp/src/types/bootstrapper.ts
@@ -6,7 +6,7 @@ export type CloudCredentials = {
 }
 
 export type Release = {
-    Name: string; 
+    Name: string;
     Version: number;
     Namespace: string;
     Status: string;
@@ -63,18 +63,18 @@ export type CreateEKSClusterRequest = {
 
 export type AWSClusterStatus = "CREATING" | "ACTIVE" | "DELETING" | "FAILED" | "UPDATING";
 
-export type AWSCluster =  {
-	Arn?: string;
-	ClientRequestToken?: string;
-	CreatedAt?: Date;
-	Endpoint?: string;
-	Id?: string;
-	Name?: string;
-	PlatformVersion?: string;
-	RoleArn?: string;
-	Status?: AWSClusterStatus; 
-	Tags?: { [key: string]: string };
-	Version?: string;
+export type AWSCluster = {
+    Arn?: string;
+    ClientRequestToken?: string;
+    CreatedAt?: Date;
+    Endpoint?: string;
+    Id?: string;
+    Name?: string;
+    PlatformVersion?: string;
+    RoleArn?: string;
+    Status?: AWSClusterStatus;
+    Tags?: { [key: string]: string };
+    Version?: string;
 }
 
 export type AWSNodeGroup = {
@@ -129,8 +129,8 @@ export const awsNodeGroupPresets: AWSNodeGroupPresets = {
         scalingConfig: { minSize: 2, maxSize: 2 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     },
     "100users": {
         preset: "100users",
@@ -139,8 +139,8 @@ export const awsNodeGroupPresets: AWSNodeGroupPresets = {
         scalingConfig: { minSize: 2, maxSize: 2 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     },
     "1000users": {
         preset: "1000users",
@@ -149,28 +149,28 @@ export const awsNodeGroupPresets: AWSNodeGroupPresets = {
         scalingConfig: { minSize: 2, maxSize: 5 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     },
     "5000users": {
         preset: "5000users",
         nodeGroupName: "",
         instanceType: "t3.large",
-        scalingConfig: { minSize: 3, maxSize: 10 }, 
+        scalingConfig: { minSize: 3, maxSize: 10 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     },
     "10000users": {
         preset: "10000users",
         nodeGroupName: "",
         instanceType: "t3.Xlarge",
-        scalingConfig: { minSize: 4, maxSize: 15 }, 
+        scalingConfig: { minSize: 4, maxSize: 15 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     },
     "25000users": {
         preset: "25000users",
@@ -179,8 +179,55 @@ export const awsNodeGroupPresets: AWSNodeGroupPresets = {
         scalingConfig: { minSize: 5, maxSize: 25 },
         amiType: "AL2_x86_64",
         releaseVersion: "1.21",
-        labels: { },
-        tags: { }
+        labels: {},
+        tags: {}
     }
 };
 
+
+interface ManagedField {
+    manager: string;
+    operation: string;
+    apiVersion: string;
+    time: string;
+    fieldsType: string;
+    fieldsV1: FieldsV1;
+}
+
+interface FieldsV1 {
+    "f:metadata": {
+        "f:labels": {
+            ".": any;
+            "f:kubernetes.io/metadata.name": any;
+            "f:name": any;
+        }
+    }
+}
+
+interface Labels {
+    "kubernetes.io/metadata.name": string;
+    name: string;
+}
+
+interface Metadata {
+    name: string;
+    uid: string;
+    resourceVersion: string;
+    creationTimestamp: string;
+    labels: Labels;
+    managedFields: ManagedField[];
+}
+
+interface Spec {
+    finalizers: string[];
+}
+
+interface Status {
+    phase: string;
+}
+
+export interface Namespace {
+    metadata: Metadata;
+    spec: Spec;
+    status: Status;
+}


### PR DESCRIPTION
#### Summary
Refactors the front-end bootstrapperSlice to remove async thunk actions (and all associated state) in favour of RTK Query. RTK Query allows for defining a queries and mutations, and then automatically exposing hooks (with very helpful utility functions and values like `isLoading` `isSuccess` `reset` and other advantages like polling)

This PR begins the implementation of the philosophy that redux-toolkit slices should only be used to store UI state.

This PR also introduces a variable `:cloudProvider` to the hash router in the front-end, much like that of the backend. The idea behind this is that it allows us to easily pick up where we left off in the front end. It will also allow us to switch between cloud providers, without having to refresh the redux store. Eventually, I'd like to implement a "cloud provider context" store in the backend (json file most likely) that would allow the user to store their credentials. This cloud provider context is intended to support multiple contexts (for multiple cloud providers), and the `:cloudProvider` variable will make this a little simpler.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

