### PR TITLE
[CLD-8202] Add Log Viewer Modal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.26
 	github.com/cloudnative-pg/cloudnative-pg v1.22.1
 	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/mattermost/awat v0.3.0
 	github.com/mattermost/mattermost-cloud v0.81.2
 	github.com/mattermost/mattermost-operator v1.21.0-rc.2
@@ -74,7 +75,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=

--- a/model/k8s.go
+++ b/model/k8s.go
@@ -7,9 +7,11 @@ import (
 	"github.com/mattermost/mattermost-cloudnative-bootstrapper/internal/logger"
 	mmclientv1beta1 "github.com/mattermost/mattermost-operator/pkg/client/v1beta1/clientset/versioned"
 	helmclient "github.com/mittwald/go-helm-client"
+	v1 "k8s.io/api/core/v1"
 	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -56,4 +58,21 @@ func (k *KubeClient) GetHelmClient(c context.Context, namespace string) (helmcli
 	}
 
 	return helmClient, nil
+}
+
+type Pod struct {
+	Name string `json:"name"`
+}
+
+func KubePodsToPods(kubePods []v1.Pod) []Pod {
+	var pods []Pod
+	for _, kubePod := range kubePods {
+		pod := Pod{
+			Name: kubePod.Name,
+		}
+
+		pods = append(pods, pod)
+	}
+
+	return pods
 }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -32,6 +32,8 @@
         "react-router-dom": "^6.20.0",
         "react-scripts": "5.0.1",
         "react-transition-group": "^4.4.5",
+        "react-virtualized-auto-sizer": "^1.0.24",
+        "react-window": "^1.8.10",
         "sass": "^1.70.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -39,7 +41,8 @@
       "devDependencies": {
         "@fontsource/inter": "^5.0.15",
         "@types/lodash": "^4.14.202",
-        "@types/react-redux": "^7.1.31"
+        "@types/react-redux": "^7.1.31",
+        "@types/react-window": "^1.8.8"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -4822,6 +4825,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.9.tgz",
       "integrity": "sha512-ZVNmWumUIh5NhH8aMD9CR2hdW0fNuYInlocZHaZ+dgk/1K49j1w/HoAuK1ki+pgscQrOFRTlXeoURtuzEkV3dg==",
       "peer": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -12821,6 +12833,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -15454,6 +15471,31 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz",
+      "integrity": "sha512-3kCn7N9NEb3FlvJrSHWGQ4iVl+ydQObq2fHMn12i5wbtm74zHOPhz/i64OL3c1S1vi9i2GXtZqNqUJTQ+BnNfg==",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -21879,6 +21921,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -27713,6 +27764,11 @@
         "fs-monkey": "^1.0.4"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -29408,6 +29464,21 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz",
+      "integrity": "sha512-3kCn7N9NEb3FlvJrSHWGQ4iVl+ydQObq2fHMn12i5wbtm74zHOPhz/i64OL3c1S1vi9i2GXtZqNqUJTQ+BnNfg==",
+      "requires": {}
+    },
+    "react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-cache": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,6 +32,8 @@
     "react-router-dom": "^6.20.0",
     "react-scripts": "5.0.1",
     "react-transition-group": "^4.4.5",
+    "react-virtualized-auto-sizer": "^1.0.24",
+    "react-window": "^1.8.10",
     "sass": "^1.70.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
@@ -63,6 +65,7 @@
   "devDependencies": {
     "@fontsource/inter": "^5.0.15",
     "@types/lodash": "^4.14.202",
-    "@types/react-redux": "^7.1.31"
+    "@types/react-redux": "^7.1.31",
+    "@types/react-window": "^1.8.8"
   }
 }

--- a/webapp/src/client/bootstrapperApi.ts
+++ b/webapp/src/client/bootstrapperApi.ts
@@ -1,13 +1,57 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { BaseQueryFn, createApi, FetchArgs, fetchBaseQuery, FetchBaseQueryError, FetchBaseQueryMeta } from '@reduxjs/toolkit/query/react';
 import { CloudCredentials, Namespace, Release, State } from "../types/bootstrapper";
 import { RootState } from '../store';
-import { baseUrl } from './client';
+import { baseUrl, wsBaseUrl } from './client';
 import { Cluster, Nodegroup } from '../types/Cluster';
+import { InstallationLogLine, Pod } from '../types/Installation';
+
+
+const websocketBaseQuery: BaseQueryFn<
+    string | FetchArgs,
+    unknown,
+    FetchBaseQueryError,
+    {},
+    FetchBaseQueryMeta
+> = async (args, api, extraOptions) => {
+    const ws = new WebSocket(`${wsBaseUrl}/api/v1${args}`);
+
+    return new Promise((resolve, reject) => {
+        ws.onerror = (e) => {
+            console.log(e);
+            reject({
+                error: {
+                    status: 'CUSTOM_ERROR',
+                    error: 'WebSocket connection error',
+                    data: e,
+                },
+                meta: {},
+            });
+        };
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            resolve({ data });
+            console.log(event);
+        };
+    });
+};
+
+const baseQuery = fetchBaseQuery({
+    baseUrl: `${baseUrl}/api/v1`,
+});
+
+const splitBaseQuery = async (args: string | FetchArgs, api: any, extraOptions: any): Promise<any> => {
+    console.log(args);
+    if (typeof args === 'string' && args.includes('ws_logs')) {
+        return websocketBaseQuery(args, api, extraOptions)
+    } else {
+        return baseQuery(args, api, extraOptions)
+    }
+};
 
 export const bootstrapperApi = createApi({
     reducerPath: 'bootstrapperApi',
-    baseQuery: fetchBaseQuery({ baseUrl: `${baseUrl}/api/v1` }),
-    tagTypes: ['BootstrapperState', 'Namespaces', 'HelmReleases', 'MattermostWorkspace', 'NginxOperator', 'CloudNativePGOperator', 'MattermostOperator', 'NginxOperator', 'CloudNativePGOperator', 'CloudCredentials'],
+    baseQuery: splitBaseQuery,
+    tagTypes: ['BootstrapperState', 'Namespaces', 'HelmReleases', 'MattermostWorkspace', 'NginxOperator', 'CloudNativePGOperator', 'MattermostOperator', 'NginxOperator', 'CloudNativePGOperator', 'CloudCredentials', 'InstallationLogs'],
     endpoints: (builder) => ({
         getState: builder.query<State, void>({
             query: () => '/state/hydrate',
@@ -69,6 +113,41 @@ export const bootstrapperApi = createApi({
                 method: 'POST',
             }),
         }),
+        getPodsForInstallation: builder.query<Pod[], { cloudProvider: string, clusterName: string, installationName: string }>({
+            query: ({ cloudProvider, clusterName, installationName }) => ({ 
+                url: `/${cloudProvider}/cluster/${clusterName}/installation/${installationName}/pods`,
+                method: 'GET',
+            }),
+        }),
+        watchInstallationLogs: builder.query<InstallationLogLine[], { cloudProvider: string; clusterName: string; installationName: string; pods: string[] }>({
+            queryFn: ({ cloudProvider, clusterName, installationName, pods }) => {
+                return { data: [] as InstallationLogLine[]};
+            },
+            keepUnusedDataFor: 0,
+            async onCacheEntryAdded(
+                arg: any,
+                { updateCachedData, cacheDataLoaded, cacheEntryRemoved }: any
+            ) {
+                const ws = new WebSocket(
+                    `${wsBaseUrl}/api/v1/${arg.cloudProvider}/cluster/${arg.clusterName}/installation/${arg.installationName}/ws_logs?${arg.pods.map((pod: string) => `pods=${pod}`).join('&')}`,
+                );
+                try {
+                    await cacheDataLoaded;
+                    const listener = (event: any) => {
+                        const logLine = JSON.parse(event.data) as InstallationLogLine;
+                        updateCachedData((draft: any) => {
+                            draft.push(logLine);
+                        });
+                    };
+                    ws.addEventListener('message', listener);
+                } catch {
+                    // no-op
+                }
+                await cacheEntryRemoved;
+                ws.close();
+            },
+            providesTags: ['InstallationLogs']
+        }),
     }),
 });
 
@@ -88,4 +167,6 @@ export const {
     useGetKubeConfigQuery,
     useGetStateQuery,
     useSetRegionMutation,
+    useWatchInstallationLogsQuery,
+    useGetPodsForInstallationQuery,
 } = bootstrapperApi;

--- a/webapp/src/client/client.ts
+++ b/webapp/src/client/client.ts
@@ -1,6 +1,7 @@
 import { CreateClusterRequest, CreateNodegroup } from "../types/Cluster";
 
 export const baseUrl = process.env.NODE_ENV == 'development' ? 'http://localhost:3000' : 'http://localhost:8070';
+export const wsBaseUrl = process.env.NODE_ENV == 'development' ? 'ws://localhost:8070' : 'ws://localhost:8070';
 
 export async function getInstallationByID(id: string) {
     const response = await fetch(`${baseUrl}/api/v1/installation/${id}`);

--- a/webapp/src/components/dashboard/installation_card.tsx
+++ b/webapp/src/components/dashboard/installation_card.tsx
@@ -3,6 +3,7 @@ import { Card, Typography, Chip, IconButton, CircularProgress, Tooltip } from '@
 import { Mattermost } from '../../types/Installation';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ListIcon from '@mui/icons-material/List';
 
 import './installation_card.scss';
 
@@ -11,17 +12,16 @@ type InstallationCardProps = {
     onClick: (installationName: string) => void;
     onClickEdit: (installationName: string) => void;
     onClickDelete: (installationName: string) => void;
+    onClickLogs: (installationName: string) => void;
 };
 
 export default function InstallationCard({
     installation,
-    onClick,
     onClickEdit,
     onClickDelete,
+    onClickLogs,
 }: InstallationCardProps) {
     const isStable = installation.status.state === 'stable';
-
-
 
     const chipWithTooltipIfApplicable = (isStable: boolean) => {
         if (isStable) {
@@ -53,7 +53,7 @@ export default function InstallationCard({
 
     return (
         <Card className="installation-card">
-            <div style={{ display: 'flex', alignItems: 'center' }}> {/* Header Section */}
+            <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Typography level="h3" style={{ flexGrow: 1 }}>
                     {installation.metadata.name}
                 </Typography>
@@ -61,7 +61,6 @@ export default function InstallationCard({
                 {chipWithTooltipIfApplicable(isStable)}
             </div>
 
-            {/* Installation Details */}
             <div>
                 <Typography>Image: {installation.status.image}</Typography>
                 <Typography>Version: {installation.status.version}</Typography>
@@ -69,10 +68,16 @@ export default function InstallationCard({
                 <Typography>Endpoint: <a href={`http://${installation.status.endpoint}`} target="_blank">{installation.status.endpoint}</a></Typography>
             </div>
 
-            {/* Button Area */}
             <div className="button-container" style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <IconButton onClick={() => onClickEdit(installation.metadata.name)} ><EditIcon /></IconButton>
-                <IconButton style={{color: 'red'}}onClick={() => onClickDelete(installation.metadata.name)}><DeleteIcon /></IconButton>
+                <Tooltip title="View logs">
+                    <IconButton onClick={() => onClickLogs(installation.metadata.name)} ><ListIcon /></IconButton>
+                </Tooltip>
+                <Tooltip title="Edit Installation">
+                    <IconButton onClick={() => onClickEdit(installation.metadata.name)} ><EditIcon /></IconButton>
+                </Tooltip>
+                <Tooltip title="Delete Installation">
+                    <IconButton style={{ color: 'red' }} onClick={() => onClickDelete(installation.metadata.name)}><DeleteIcon /></IconButton>
+                </Tooltip>
             </div>
         </Card>
     );

--- a/webapp/src/components/dashboard/logs_modal/index.tsx
+++ b/webapp/src/components/dashboard/logs_modal/index.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Modal from '@mui/joy/Modal';
+import ModalDialog from '@mui/joy/ModalDialog';
+import Divider from '@mui/material/Divider';
+import ModalClose from '@mui/joy/ModalClose';
+import { Mattermost } from '../../../types/Installation';
+import { useGetPodsForInstallationQuery, useWatchInstallationLogsQuery } from '../../../client/bootstrapperApi';
+
+import './log_viewer_modal.scss';
+import { Checkbox } from '@mui/joy';
+
+interface LogViewerModalProps {
+    installation: Mattermost;
+    clusterName: string;
+    cloudProvider: string;
+    onClose?: () => void;
+}
+
+const LOG_LINE_PREFIX = '$ '; // Log line indicator
+
+export default function LogViewerModal({ installation, clusterName, cloudProvider, onClose }: LogViewerModalProps) {
+    const [selectedPods, setSelectedPods] = useState<string[]>([]);
+    const [autoScroll, setAutoScroll] = useState(true);
+    const { data: logs, error } = useWatchInstallationLogsQuery({
+        cloudProvider,
+        clusterName,
+        installationName: installation.metadata.name,
+        pods: selectedPods,
+    }, { skip: !installation?.metadata?.name || !clusterName || !cloudProvider || selectedPods.length === 0 });
+
+    const { data: pods, error: fetchPodsError } = useGetPodsForInstallationQuery({
+        cloudProvider,
+        clusterName,
+        installationName: installation.metadata.name,
+    });
+
+
+    const bottomRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (autoScroll) {
+            bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+        }
+    }, [logs, autoScroll]);
+
+    const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const podName = event.target.value;
+        if (event.target.checked) {
+            setSelectedPods((prevSelected) => [...prevSelected, podName]);
+        } else {
+            setSelectedPods((prevSelected) => prevSelected.filter((name) => name !== podName));
+        }
+    };
+
+    return (
+        <Modal open={true} onClose={onClose}>
+            <ModalDialog
+                aria-labelledby="basic-modal-dialog-title"
+                aria-describedby="basic-modal-dialog-description"
+                sx={{
+                    maxWidth: 1500,
+                    minWidth:
+                        1500,
+                    minHeight: 860,
+                    maxHeight: 860,
+                }}
+                className="LogViewerModal"
+            >
+                <ModalClose />
+                <h2
+                    id="basic-modal-dialog-title"
+                >
+                    {installation.metadata.name} logs
+                </h2>
+                <Divider />
+                <div className="pod-selectors">
+                    <label>Select pod(s):</label>
+                    {/* map pod list to checkboxes for selection */}
+                    <div className="pod-list">
+                        {pods?.map((pod, index) => (
+                            <div key={index}>
+                                <Checkbox label={pod.name} id={`pod-${index}`} name={`pod-${index}`} value={pod.name} checked={selectedPods.includes(pod.name)} onChange={handleCheckboxChange} />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                {Boolean(selectedPods.length) &&
+                    <>
+                        <div className="auto-scroll-checkbox">
+                            <Checkbox label="Enable auto scroll" checked={autoScroll} onChange={(e) => setAutoScroll(e.target.checked)} />
+                        </div>
+                        <Box
+                            id="basic-modal-dialog-description"
+                            sx={{
+                                maxHeight: 600,
+                                overflow: 'auto',
+                                backgroundColor: '#282c34', // Dark background for terminal look
+                                color: '#fff',
+                                fontFamily: 'monospace',
+                                padding: 2,
+                                borderRadius: '4px',
+                                whiteSpace: 'pre-wrap', // Allow wrapping
+                            }}
+                        >
+                            {error &&
+
+                                <div>
+                                    Error fetching logs: {error.message}
+                                </div>
+                            }
+                            {logs?.map((logLine, index) => (
+                                <div key={index}>
+                                    {index}{' '}{LOG_LINE_PREFIX}
+                                    {JSON.stringify(logLine)}
+                                </div>
+                            ))}
+                            <div ref={bottomRef} />
+                        </Box>
+                    </>
+                }
+                {Boolean(!selectedPods.length) && <div className="no-pods-selected">No pods selected</div>}
+            </ModalDialog>
+        </Modal>
+    );
+}

--- a/webapp/src/components/dashboard/logs_modal/log_viewer_modal.scss
+++ b/webapp/src/components/dashboard/logs_modal/log_viewer_modal.scss
@@ -1,0 +1,32 @@
+.LogViewerModal {
+    #basic-modal-dialog-description {
+        overflow-x: hidden;
+        word-break: break-all;
+    }
+
+    .pod-selectors {
+        .pod-list {
+            margin-top: 10px;
+            margin-bottom: 10px;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 10px;
+            padding: 12px;
+            // New styles for limiting rows and enabling scrolling
+            max-height: calc(5 * 35px + 10px); // Adjust 30px if your row height is different
+            overflow-y: scroll; 
+            border: 1px lightgray solid;
+            border-radius: 12px;
+            :hover {
+                cursor: pointer;
+            }
+        }
+    }
+
+    .no-pods-selected {
+        margin-top: 15px;
+        display: flex !important;
+        justify-content: center;
+        align-items: center;
+    }
+}

--- a/webapp/src/pages/dashboard/index.tsx
+++ b/webapp/src/pages/dashboard/index.tsx
@@ -12,6 +12,7 @@ import CreateInstallationCard from '../../components/dashboard/create_installati
 import { Mattermost, PatchMattermostWorkspaceRequest } from '../../types/Installation';
 import { Button, CircularProgress } from '@mui/joy';
 import EditInstallationModal from '../../components/dashboard/edit_installation_modal';
+import LogViewerModal from '../../components/dashboard/logs_modal';
 
 export default function InstallationDashboard() {
     const dispatch = useDispatch();
@@ -20,6 +21,7 @@ export default function InstallationDashboard() {
     const cloudProvider = useMatch('/:cloudProvider/dashboard')?.params.cloudProvider!;
     const selectedClusterName = useSelector((state: RootState) => state.dashboard.selectedClusterName);
     const installationToEdit = useSelector((state: RootState) => state.dashboard.installationToEdit);
+    const [installationToLog, setInstallationToLog] = useState<Mattermost | undefined>(undefined);
     const { data: installations, isLoading, error: installationsError, refetch: refetchInstallations } = useGetMattermostInstallationsForClusterQuery({ cloudProvider, clusterName: selectedClusterName! }, {
         skip: !selectedClusterName, // Only fetch if cluster name is defined
         pollingInterval: 10000,
@@ -58,6 +60,11 @@ export default function InstallationDashboard() {
         }) as any);
     }
 
+    const handleOnClickLogs = (installationName: string) => {
+        const installation = installations?.filter((install) => install.metadata.name === installationName)[0];
+        setInstallationToLog(installation);
+    }
+
     const handleEditModalOnChange = (installation: PatchMattermostWorkspaceRequest) => {
         dispatch(setInstallationToEdit(installation) as any);
     }
@@ -74,7 +81,7 @@ export default function InstallationDashboard() {
 
     const installationsSection = (installs: Mattermost[]) => {
         return (
-            <div className="installation-cards">{installs.map((install) => <InstallationCard installation={install} onClick={() => { }} onClickEdit={handleEditInstallation} onClickDelete={(installationName) => { deleteInstallation({ clusterName: selectedClusterName!, cloudProvider, installationName }) }} />)}
+            <div className="installation-cards">{installs.map((install) => <InstallationCard installation={install} onClick={() => { }} onClickEdit={handleEditInstallation} onClickDelete={(installationName) => { deleteInstallation({ clusterName: selectedClusterName!, cloudProvider, installationName }) }} onClickLogs={handleOnClickLogs} />)}
                 <CreateInstallationCard onClick={() => navigate(`/${cloudProvider}/create_mattermost_workspace?clusterName=${selectedClusterName}`)} />
             </div>
         )
@@ -100,6 +107,7 @@ export default function InstallationDashboard() {
                 selectedClusterName && !isLoading && !isFetching && installationsError && <div className="installations-section-error">Error fetching installations</div>
             }
             <EditInstallationModal show={typeof installationToEdit !== 'undefined'} installation={installationToEdit} onClose={handleOnCloseEditModal} onChange={handleEditModalOnChange} onSubmit={handleSubmitEditModal} />
+            {installationToLog && <LogViewerModal installation={installationToLog} clusterName={selectedClusterName!} cloudProvider={cloudProvider} onClose={() => setInstallationToLog(undefined)}/>}
         </div>
     );
 }

--- a/webapp/src/types/Installation.ts
+++ b/webapp/src/types/Installation.ts
@@ -149,3 +149,19 @@ export interface Status {
     updatedReplicas: number;
     observedGeneration: number;
 }
+
+export interface InstallationLogLine {
+    timestamp: Date;
+    level?: string;
+    msg: string;
+    caller?: string;
+    method?: string;
+    url?: string;
+    request_id?: string;
+    user_id?: string;
+    status_code?: string;
+}
+
+export interface Pod {
+    name: string;
+}


### PR DESCRIPTION
#### Summary
Adds new Log Viewer Modal, giving users the ability to watch pod logs from the Dashboard for a given installation.

The installation card now has a button to View Logs
![image](https://github.com/user-attachments/assets/c67a9348-0d67-4226-8aae-c2400d2520c0)
Clicking the button opens the installation log modal:
![image](https://github.com/user-attachments/assets/3e0200e5-054e-4978-8c75-a5c910eefa4f)
By selecting one or more pods, the logs for said pods will be written to the log viewer section
![image](https://github.com/user-attachments/assets/0205c7d3-5917-406b-a231-991a4664f122)
Auto scroll can be enabled, or disabled, allowing you to inspect specific areas of the log without it bumping you back to the bottom
![image](https://github.com/user-attachments/assets/4dcf545e-546b-4ced-91d2-78d94c9eba08)


This log viewer is powered via RTK Query, and a Websocket connection to the backend. The backend uses n + 1 go routines, where n is the number of selected pods (one go routine to monitor logs from each pod) and the + 1 is an extra go routine, which handles accepting logs from each of the pod watching go routines, then writing to the websocket. The + 1 go routine is necessary to prevent panics due to concurrent writes to a websocket connection that happens if the n pods emit logs at overlapping times. 


#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8202

