### PR TITLE
fix: environment fixes from trial run

### DIFF
--- a/api/bootstrapper.go
+++ b/api/bootstrapper.go
@@ -421,6 +421,12 @@ func handleDeployNginxOperator(c *Context, w http.ResponseWriter, r *http.Reques
 
 	// TODO - we need some sort of pre-post hooks for the install to allow for environment specific configurations
 	valuesYaml := `controller:
+    config:
+      use-forwarded-headers: "true"
+	service:
+	  targetPorts:
+	    http: http
+		https: http
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"


### PR DESCRIPTION
#### Summary
- Adds `use-forwarded-headers: "true"` for the initial configmap creation
- Uses `http` as target port for the `https` service
